### PR TITLE
refactor(docker): Make Docker setup fully dynamic via .env

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This method uses a smart script to download all necessary files and run the serv
 
     **On Debian/Ubuntu-based systems:**
     ```bash
-    sudo apt-get install openjdk-17-jdk ffmpeg gettext curl
+    sudo apt-get install openjdk-17-jdk ffmpeg gettext-base curl
     ```
 
     **On Fedora/CentOS/Rocky-based systems:**

--- a/application.yml.template
+++ b/application.yml.template
@@ -1,5 +1,5 @@
 server:
-  port: 2333
+  port: ${LAVALINK_PORT}
   address: 0.0.0.0
   http2:
     enabled: true
@@ -14,11 +14,6 @@ lavalink:
       spotify: false
       deezer: false
       applemusic: false
-
-  plugins:
-    - dependency: "dev.lavalink.youtube:youtube-plugin:1.13.5"
-      snapshot: false
-    - dependency: "com.github.topi314.lavasrc:lavasrc-plugin:4.8.1"
 
 plugins:
   youtube:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,26 +1,29 @@
 version: "3.8"
 
+env_file:
+  - .env
+
 services:
   lavalink:
     build:
       context: .
       dockerfile: Dockerfile
       args:
-        LAVALINK_VERSION: "4.1.1"
-        YOUTUBE_PLUGIN_VERSION: "1.13.5"
-        LAVASRC_PLUGIN_VERSION: "4.8.1"
+        LAVALINK_VERSION: "${LAVALINK_VERSION:-4.1.1}"
+        YOUTUBE_PLUGIN_VERSION: "${YOUTUBE_PLUGIN_VERSION:-1.13.5}"
+        LAVASRC_PLUGIN_VERSION: "${LAVASRC_PLUGIN_VERSION:-4.8.1}"
     image: myorg/lavalink:latest
     container_name: lavalink
     env_file:
-      - .env.lavalink
+      - .env
     ports:
-      - "2333:2333"
+      - "${LAVALINK_PORT:-2333}:${LAVALINK_PORT:-2333}"
     volumes:
       - ./plugins:/app/plugins
       - ./data:/app/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://127.0.0.1:2333/"]
+      test: "curl -f http://127.0.0.1:${LAVALINK_PORT:-2333}/ || exit 1"
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
This commit refactors the Docker configuration to eliminate hardcoded values and align it with the dynamic nature of the local setup. Previously, the `docker-compose.yml` file used fixed version numbers and ports, ignoring any user-defined values in the `.env` file.

The `docker-compose.yml` now reads all build arguments (versions) and runtime settings (ports, healthcheck) directly from `.env`, making it the single source of truth.

Additionally, the `application.yml.template` has been simplified by removing the redundant plugin loader section, fully relying on the automatic loading mechanism for a cleaner and more robust configuration.