### PR TITLE
feat(config): Make YouTube clients configurable via .env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ YOUTUBE_CLIENT_ID=
 YOUTUBE_CLIENT_SECRET=
 YOUTUBE_REFRESH_TOKEN=
 
+# YouTube clients to use, separated by commas.
+YOUTUBE_CLIENTS="ANDROID_VR"
+
 # --- Pot (YouTube alt plugin) ---
 POT_TOKEN=
 POT_VISITOR_DATA=

--- a/application.yml.template
+++ b/application.yml.template
@@ -22,8 +22,7 @@ plugins:
     allowDirectVideoIds: true
     allowDirectPlaylistIds: true
     clients:
-      - TV
-      - TVHTML5EMBEDDED
+      - YOUTUBE_CLIENTS_PLACEHOLDER
 
     oauth:
       enabled: true
@@ -43,3 +42,4 @@ plugins:
       clientId: "${SPOTIFY_CLIENT_ID}"
       clientSecret: "${SPOTIFY_CLIENT_SECRET}"
       countryCode: "${SPOTIFY_COUNTRY}"
+

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ for cmd in curl java envsubst; do
         echo "Error: Command '$cmd' not found." >&2
         echo "Please ensure it is installed and available in your PATH." >&2
         if [ "$cmd" = "envsubst" ]; then
-            echo "Tip: 'envsubst' is part of the 'gettext' package (e.g., 'sudo apt install gettext')." >&2
+            echo "Tip: 'envsubst' is part of the 'gettext' package (e.g., 'sudo apt install gettext-base')." >&2
         fi
         exit 1
     fi
@@ -21,6 +21,7 @@ fi
 : "${LAVALINK_VERSION:=4.1.1}"
 : "${YOUTUBE_PLUGIN_VERSION:=1.13.5}"
 : "${LAVASRC_PLUGIN_VERSION:=4.8.1}"
+: "${YOUTUBE_CLIENTS:=TV,TVHTML5EMBEDDED}"
 
 LAVALINK_JAR="$SCRIPT_DIR/Lavalink.jar"
 PLUGINS_DIR="$SCRIPT_DIR/plugins"
@@ -54,7 +55,15 @@ if [ ! -f "$LAVASRC_PLUGIN_JAR" ]; then
 fi
 
 echo "Generating application.yml from template..."
+
 envsubst < "$TEMPLATE_FILE" > "$OUTPUT_FILE"
+
+YOUTUBE_CLIENTS_YAML_LIST=$(echo "${YOUTUBE_CLIENTS}" | sed 's/,/\n      - /g')
+
+sed -i.bak "s|YOUTUBE_CLIENTS_PLACEHOLDER|- ${YOUTUBE_CLIENTS_YAML_LIST}|g" "$OUTPUT_FILE"
+
+rm -f "$OUTPUT_FILE.bak"
+
 echo "Configuration file created."
 
 echo "Starting Lavalink server..."


### PR DESCRIPTION
Adds the ability for users to specify which YouTube clients Lavalink should use directly from the `.env` file via a new `YOUTUBE_CLIENTS` variable.

Previously, the client list was hardcoded in the `application.yml.template`, making it difficult to change without modifying tracked project files.

The `start.sh` script has been enhanced to parse this new comma-separated variable and correctly format it into the final `application.yml`.

This feature provides greater flexibility, allowing users to easily adapt to changes in YouTube's API or select specific clients for troubleshooting without altering the core project templates.