### PR TITLE
fix(script): Implement robust .env loading and YAML generation

### DIFF
--- a/application.yml.template
+++ b/application.yml.template
@@ -21,9 +21,8 @@ plugins:
     allowSearch: true
     allowDirectVideoIds: true
     allowDirectPlaylistIds: true
-    clients:
-      - YOUTUBE_CLIENTS_PLACEHOLDER
-
+    clients: 
+${YOUTUBE_CLIENTS_YAML}
     oauth:
       enabled: true
       clientId: "${YOUTUBE_CLIENT_ID}"
@@ -42,4 +41,3 @@ plugins:
       clientId: "${SPOTIFY_CLIENT_ID}"
       clientSecret: "${SPOTIFY_CLIENT_SECRET}"
       countryCode: "${SPOTIFY_COUNTRY}"
-


### PR DESCRIPTION
The previous `start.sh` script had two critical flaws. First, the method for loading the `.env` file was unreliable, causing "invalid identifier" errors when variables contained spaces or multiple comma-separated values. Second, the two-step `envsubst` and `sed` process for generating `application.yml` was fragile and often produced invalid YAML.

This commit replaces the faulty logic with a robust, unified approach. The `.env` file is now sourced safely, preserving all variable formatting. The YAML generation has been streamlined into a single, reliable `envsubst` operation that uses a pre formatted variable, ensuring the final configuration is always valid and correctly reflects the user's settings.